### PR TITLE
Default Parallel Runners

### DIFF
--- a/behave/__main__.py
+++ b/behave/__main__.py
@@ -1,26 +1,20 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, print_function
-
 import codecs
 import sys
-
 import six
-
-from behave.configuration import Configuration
-from behave.exception import (ClassNotFoundError, ConfigError, ConstraintError,
-                              FileNotFoundError, InvalidClassError,
-                              InvalidFileLocationError, InvalidFilenameError,
-                              ModuleNotFoundError)
-from behave.parser import ParserError
-from behave.runner_parallel import (FeatureParallelRunner,
-                                    ScenarioParallelRunner)
-from behave.runner_plugin import RunnerPlugin
-from behave.runner_util import print_undefined_step_snippets, reset_runtime
-from behave.textutil import compute_words_maxsize
-from behave.textutil import text as _text
 from behave.version import VERSION as BEHAVE_VERSION
-
+from behave.configuration import Configuration
+from behave.exception import ConstraintError, ConfigError, \
+    FileNotFoundError, InvalidFileLocationError, InvalidFilenameError, \
+    ModuleNotFoundError, ClassNotFoundError, InvalidClassError
+from behave.parser import ParserError
+from behave.runner import Runner
+from behave.runner_parallel import FeatureParallelRunner, ScenarioParallelRunner
+from behave.runner_util import print_undefined_step_snippets, reset_runtime
+from behave.textutil import compute_words_maxsize, text as _text
+from behave.runner_plugin import RunnerPlugin
 # PREPARED: from behave.importer import make_scoped_class_name
 
 
@@ -102,7 +96,7 @@ def run_behave(config, runner_class=None):
         return 0
 
     if len(config.outputs) > len(config.format):
-        print("CONFIG-ERROR: More outfiles (%d) than formatters (%d)." %
+        print("CONFIG-ERROR: More outfiles (%d) than formatters (%d)." % \
               (len(config.outputs), len(config.format)))
         return 1
 
@@ -126,6 +120,7 @@ def run_behave(config, runner_class=None):
     try:
         reset_runtime()
         runner = RunnerPlugin(runner_class).make_runner(config)
+        # print("USING RUNNER: {0}".format(make_scoped_class_name(runner)))
         failed = runner.run()
     except ParserError as e:
         print(u"ParserError: %s" % e)
@@ -193,7 +188,6 @@ def print_language_list(file=None):
 
 def print_language_help(language, file=None):
     from behave.i18n import languages
-
     # if stream is None:
     #     stream = sys.stdout
     #     if six.PY2:
@@ -223,9 +217,8 @@ def print_formatters(file=None):
 
     :param file:  Optional, output file to use (default: sys.stdout).
     """
-    from operator import itemgetter
-
     from behave.formatter._registry import format_items
+    from operator import itemgetter
 
     print_ = lambda text: print(text, file=file)
 

--- a/behave/__main__.py
+++ b/behave/__main__.py
@@ -7,16 +7,12 @@ import sys
 
 import six
 
-from behave.configuration import (DEFAULT_FEATURE_PARALLEL_RUNNER,
-                                  DEFAULT_RUNNER_CLASS_NAME,
-                                  DEFAULT_SCENARIO_PARALLEL_RUNNER,
-                                  Configuration)
+from behave.configuration import Configuration
 from behave.exception import (ClassNotFoundError, ConfigError, ConstraintError,
                               FileNotFoundError, InvalidClassError,
                               InvalidFileLocationError, InvalidFilenameError,
                               ModuleNotFoundError)
 from behave.parser import ParserError
-from behave.runner import Runner
 from behave.runner_parallel import (FeatureParallelRunner,
                                     ScenarioParallelRunner)
 from behave.runner_plugin import RunnerPlugin

--- a/behave/__main__.py
+++ b/behave/__main__.py
@@ -106,7 +106,7 @@ def run_behave(config, runner_class=None):
         return 0
 
     if len(config.outputs) > len(config.format):
-        print("CONFIG-ERROR: More outfiles (%d) than formatters (%d)." % \
+        print("CONFIG-ERROR: More outfiles (%d) than formatters (%d)." %
               (len(config.outputs), len(config.format)))
         return 1
 
@@ -116,12 +116,13 @@ def run_behave(config, runner_class=None):
 
     # -- HANDLE MULTIPROCESSING
     # Use default parallel runner if custom not provided
-    if config.jobs > 1 and (not runner_class or isinstance(runner_class, Runner)):
+    if config.jobs > 1 and not runner_class:
         if config.parallel_element == "feature":
             runner_class = FeatureParallelRunner
         else:
             runner_class = ScenarioParallelRunner
-        print("INFO: As number of processes/jobs > 1 - using Parallel Runner: %s" % runner_class.__name__)
+        print("INFO: Number of jobs > 1 - using Parallel Runner: %s" % 
+            runner_class.__name__)
 
     # -- MAIN PART:
     runner = None

--- a/behave/arg_parser.py
+++ b/behave/arg_parser.py
@@ -1,0 +1,37 @@
+"""Object for parsing command line strings into Python objects.
+
+Extends default ArgumentParser to pass validation errors to the output
+"""
+
+import sys as _sys
+from argparse import ArgumentError, ArgumentParser, ArgumentTypeError
+from gettext import gettext as _
+
+
+class BehaveArgParser(ArgumentParser):
+    def _get_value(self, action, arg_string):
+        type_func = self._registry_get('type', action.type, action.type)
+
+        if not callable(type_func):
+            msg = _('%r is not callable')
+            raise ArgumentError(action, msg % type_func)
+
+        # convert the value to the appropriate type
+        try:
+            result = type_func(arg_string)
+
+        # ArgumentTypeErrors indicate errors
+        except ArgumentTypeError:
+            name = getattr(action.type, '__name__', repr(action.type))
+            msg = str(_sys.exc_info()[1])
+            raise ArgumentError(action, msg)
+
+        # TypeErrors or ValueErrors also indicate errors
+        except (TypeError, ValueError) as e:
+            name = getattr(action.type, '__name__', repr(action.type))
+            args = {'type': name, 'value': arg_string, 'traceback': e}
+            msg = _('invalid %(type)s value: %(value)r: %(traceback)s')
+            raise ArgumentError(action, msg % args)
+
+        # return the converted value
+        return result

--- a/behave/capture.py
+++ b/behave/capture.py
@@ -4,12 +4,9 @@ Capture output (stdout, stderr), logs, etc.
 """
 
 from __future__ import absolute_import
-
-import sys
 from contextlib import contextmanager
-
-from six import PY2, StringIO
-
+import sys
+from six import StringIO, PY2
 from behave.log_capture import LoggingCapture
 from behave.textutil import text as _text
 

--- a/behave/capture.py
+++ b/behave/capture.py
@@ -4,11 +4,15 @@ Capture output (stdout, stderr), logs, etc.
 """
 
 from __future__ import absolute_import
-from contextlib import contextmanager
+
 import sys
-from six import StringIO, PY2
+from contextlib import contextmanager
+
+from six import PY2, StringIO
+
 from behave.log_capture import LoggingCapture
 from behave.textutil import text as _text
+
 
 def add_text_to(value, more_text, separator="\n"):
     if more_text:
@@ -104,6 +108,19 @@ class Captured(object):
             assert captured1.stdout == "Hello\nWorld"
         """
         return self.add(other)
+
+    def send_status(self):
+        ret = {'stdout': self.stdout,
+               'stderr': self.stderr,
+               'log_output': self.log_output,
+               }
+        return ret
+
+    def recv_status(self, value):
+        assert not self, "Captured already has content"
+        for k in 'stdout', 'stderr', 'log_output':
+            if k in value:
+                setattr(self, k, value[k])
 
 
 class CaptureController(object):

--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -1,28 +1,27 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, print_function
-
+import inspect
 import logging
 import multiprocessing
 import os
 import re
-import shlex
 import sys
-
+import shlex
 import six
 from six.moves import configparser
 
-from behave._types import Unknown
-from behave.arg_parser import ArgumentTypeError, BehaveArgParser
-from behave.formatter import _registry as _format_registry
-from behave.formatter.base import StreamOpener
+from behave.arg_parser import BehaveArgParser, ArgumentTypeError
 from behave.model import ScenarioOutline
 from behave.model_core import FileLocation
 from behave.reporter.junit import JUnitReporter
 from behave.reporter.summary import SummaryReporter
 from behave.tag_expression import make_tag_expression
-from behave.textutil import select_best_encoding, to_texts
+from behave.formatter.base import StreamOpener
+from behave.formatter import _registry as _format_registry
 from behave.userdata import UserData, parse_user_define
+from behave._types import Unknown
+from behave.textutil import select_best_encoding, to_texts
 
 # -- PYTHON 2/3 COMPATIBILITY:
 # SINCE Python 3.2: ConfigParser = SafeConfigParser

--- a/behave/model.py
+++ b/behave/model.py
@@ -2,7 +2,6 @@
 # pylint: disable=too-many-lines
 """
 This module provides the model element class that represent a behave model:
-
 * :class:`Feature`
 * :class:`Scenario`
 * :class:`ScenarioOutline`
@@ -10,22 +9,18 @@ This module provides the model element class that represent a behave model:
 * ...
 """
 
-from __future__ import absolute_import, print_function, with_statement
-
+from __future__ import absolute_import, with_statement, print_function
 import copy
 import difflib
-import itertools
 import logging
+import itertools
 import time
-
 import six
-from six.moves import zip  # pylint: disable=redefined-builtin
-
+from six.moves import zip       # pylint: disable=redefined-builtin
+from behave.model_core import \
+        Status, BasicStatement, TagAndStatusStatement, TagStatement, Replayable
 from behave.matchers import NoMatch
-from behave.model_core import (BasicStatement, Replayable, Status,
-                               TagAndStatusStatement, TagStatement)
 from behave.textutil import text as _text
-
 if six.PY2:
     # -- USE PYTHON3 BACKPORT: With unicode traceback support.
     import traceback2 as traceback

--- a/behave/model.py
+++ b/behave/model.py
@@ -10,18 +10,22 @@ This module provides the model element class that represent a behave model:
 * ...
 """
 
-from __future__ import absolute_import, with_statement, print_function
+from __future__ import absolute_import, print_function, with_statement
+
 import copy
 import difflib
-import logging
 import itertools
+import logging
 import time
+
 import six
-from six.moves import zip       # pylint: disable=redefined-builtin
-from behave.model_core import \
-        Status, BasicStatement, TagAndStatusStatement, TagStatement, Replayable
+from six.moves import zip  # pylint: disable=redefined-builtin
+
 from behave.matchers import NoMatch
+from behave.model_core import (BasicStatement, Replayable, Status,
+                               TagAndStatusStatement, TagStatement)
 from behave.textutil import text as _text
+
 if six.PY2:
     # -- USE PYTHON3 BACKPORT: With unicode traceback support.
     import traceback2 as traceback
@@ -181,6 +185,33 @@ class ScenarioContainer(TagAndStatusStatement, Replayable):
         for run_item in self.run_items:
             run_item.reset()
 
+    def send_status(self):
+        ret = super(ScenarioContainer, self).send_status()
+        ret['hook_failed'] = self.hook_failed
+        ret['scenarios'] = {}
+        for scenario in self.scenarios:
+            ret['scenarios'][hash(scenario)] = scenario.send_status()
+        return ret
+
+    def recv_status(self, value):
+        super(ScenarioContainer, self).recv_status(value)
+        if 'hook_failed' in value:
+            self.hook_failed = value['hook_failed']
+        if 'scenarios' in value:
+            for scenario in self.scenarios:
+                sval = value['scenarios'].get(hash(scenario))
+                if sval is not None:
+                    scenario.recv_status(sval)
+
+    @property
+    def is_finished(self):
+        if self._cached_status in self.final_status:
+            return True
+        for s in self.walk_scenarios():
+            if not s.is_finished:
+                return False
+        return True
+
     def _setup_context_for_run(self, context):
         """Setup/Init runner context for run."""
         # -- OVERRIDDEN: By derived classes.
@@ -235,10 +266,14 @@ class ScenarioContainer(TagAndStatusStatement, Replayable):
     def duration(self):
         # -- NEW: Background is executed N times, now part of scenarios.
         # TODO: Use self.run_endtime - self.run_starttime
-        feature_duration = 0.0
+        if self.background:
+            feature_duration = self.background.duration or 0.0
+        else:
+            feature_duration = 0.0
         # -- OLD IMPLEMENTATION:
         for scenario in self.scenarios:
             feature_duration += scenario.duration
+
         # -- NEW IMPLEMENTATION:
         # feature_duration = self.run_endtime - self.run_starttime
         return feature_duration
@@ -941,6 +976,9 @@ class Scenario(TagAndStatusStatement, Replayable):
         self._row = None
         self.was_dry_run = False
 
+    def __hash__(self):
+        return hash((self.filename, self.line, self.keyword, self.name))
+
     def reset(self):
         """Reset the internal data to reintroduce new-born state just after the
         ctor was called.
@@ -951,6 +989,29 @@ class Scenario(TagAndStatusStatement, Replayable):
         self.was_dry_run = False
         for step in self.all_steps:
             step.reset()
+
+    def send_status(self):
+        ret = super(Scenario, self).send_status()
+        ret['hook_failed'] = self.hook_failed
+        ret['was_dry_run'] = self.was_dry_run
+
+        ret['steps'] = {}
+        for step in self.all_steps:
+            ret['steps'][hash(step)] = step.send_status()
+        return ret
+
+    def recv_status(self, value):
+        super(Scenario, self).recv_status(value)
+        if 'hook_failed' in value:
+            self.hook_failed = value['hook_failed']
+        if 'was_dry_run' in value:
+            self.was_dry_run = value['was_dry_run']
+        if 'steps' in value:
+            steps_v = value['steps']
+            for step in self.all_steps:
+                sval = steps_v.get(hash(step), None)
+                if sval is not None:
+                    step.recv_status(sval)
 
     @property
     def use_background(self):
@@ -1011,6 +1072,15 @@ class Scenario(TagAndStatusStatement, Replayable):
 
     def __iter__(self):
         return self.iter_steps()
+
+    @property
+    def is_finished(self):
+        if self._cached_status in self.final_status:
+            return True
+        for s in self.all_steps:
+            if s.status not in self.final_status:
+                return False
+        return True
 
     def compute_status(self):
         """Compute the status of the scenario from its steps
@@ -1106,6 +1176,15 @@ class Scenario(TagAndStatusStatement, Replayable):
             self.set_status(Status.skipped)
         assert self.status in self.final_status #< skipped, failed or passed
 
+    def force_pass(self, reason=None):
+        """Mark scenario as passed and skip any remaining steps
+        """
+        assert self._cached_status == Status.untested, self._cached_status
+        assert not self.should_skip
+        self.skip_reason = reason
+        self._cached_status = Status.passed
+        self.should_skip = 'pass'
+
     def run(self, runner):
         # pylint: disable=too-many-branches, too-many-statements
         self.clear_status()
@@ -1192,7 +1271,8 @@ class Scenario(TagAndStatusStatement, Replayable):
                     #   * Step skipped remaining scenario.
                     step.status = Status.skipped
 
-        self.clear_status()  # -- ENFORCE: compute_status() after run.
+        if self.should_skip != 'pass':
+            self.clear_status()  # -- ENFORCE: compute_status() after run.
         if not run_scenario and not self.steps:
             # -- SPECIAL CASE: Scenario without steps.
             self.set_status(Status.skipped)
@@ -1603,6 +1683,31 @@ class ScenarioOutline(Scenario):
         runner.context._set_root_attribute("active_outline", None)
         return failed_count > 0
 
+    def send_status(self):
+        ret = super(ScenarioOutline, self).send_status()
+        ret['sub_scenarios'] = {}
+        for scenario in self._scenarios:
+            ret['sub_scenarios'][hash(scenario)] = scenario.send_status()
+        return ret
+
+    def recv_status(self, value):
+        if 'sub_scenarios' in value:
+            sub_scens = value['sub_scenarios']
+            for scenario in self.scenarios:
+                sval = sub_scens.get(hash(scenario))
+                if sval is not None:
+                    scenario.recv_status(sval)
+
+    @property
+    def is_finished(self):
+        if self._cached_status in self.final_status:
+            return True
+        for s in self._scenarios:
+            if not s.is_finished:
+                return False
+        return True
+
+
 class Examples(TagStatement, Replayable):
     """A table parsed from a `scenario outline`_ in a *feature file*.
 
@@ -1639,6 +1744,9 @@ class Examples(TagStatement, Replayable):
         super(Examples, self).__init__(filename, line, keyword, name, tags)
         self.table = table
         self.index = None
+
+    def __hash__(self):
+        return hash((self.filename, self.line, self.step_type, self.name))
 
 
 class Step(BasicStatement, Replayable):
@@ -1741,6 +1849,22 @@ class Step(BasicStatement, Replayable):
         self.duration = 0
         # -- POSTCONDITION: assert self.status == Status.untested
 
+    def send_status(self):
+        ret = super(Step, self).send_status()
+        ret['status'] = self.status
+        ret['hook_failed'] = self.hook_failed
+        ret['duration'] = self.duration
+        return ret
+
+    def recv_status(self, value):
+        super(Step, self).recv_status(value)
+        if 'status' in value:
+            self.status = value['status']
+        if 'hook_failed' in value:
+            self.hook_failed = value['hook_failed']
+        if 'duration' in value:
+            self.duration = value['duration']
+
     def __repr__(self):
         return '<%s "%s">' % (self.step_type, self.name)
 
@@ -1813,6 +1937,11 @@ class Step(BasicStatement, Replayable):
                 if self.status == Status.untested:
                     # -- NOTE: Executed step may have skipped scenario and itself.
                     self.status = Status.passed
+                elif self.status == Status.skipped:
+                    # scenario has just skipped (after running this step)
+                    # then this step must keep reason for skipping
+                    self.error_message = runner.context.scenario.skip_reason \
+                                         or self.error_message
             except KeyboardInterrupt as e:
                 runner.abort(reason="KeyboardInterrupt")
                 error = u"ABORTED: By user (KeyboardInterrupt)."
@@ -1841,7 +1970,7 @@ class Step(BasicStatement, Replayable):
             runner.stop_capture()
 
         # flesh out the failure with details
-        store_captured_always = False   # PREPARED
+        store_captured_always = True   # PREPARED
         store_captured = self.status == Status.failed or store_captured_always
         if self.status == Status.failed:
             assert isinstance(error, six.text_type)
@@ -2130,6 +2259,9 @@ class Tag(six.text_type):
         o.line = line
         return o
 
+    def __getnewargs__(self):
+        return (six.text_type(self), self.line)
+
     @classmethod
     def make_name(cls, text, unescape=False, allowed_chars=None):
         """Translate text into a "valid tag" without whitespace, etc.
@@ -2197,6 +2329,9 @@ class Text(six.text_type):
         o.content_type = content_type
         o.line = line
         return o
+
+    def __getnewargs__(self):
+        return (six.text_type(self), self.content_type, self.line)
 
     def line_range(self):
         line_count = len(self.splitlines())

--- a/behave/model_core.py
+++ b/behave/model_core.py
@@ -6,12 +6,12 @@ for the model elements in behave.
 
 import os.path
 import sys
-from enum import Enum
 
 import six
 
 from behave.capture import Captured
 from behave.textutil import text as _text
+from enum import Enum
 
 if six.PY2:
     # -- USE: Python3 backport for better unicode compatibility.

--- a/behave/model_core.py
+++ b/behave/model_core.py
@@ -6,10 +6,18 @@ for the model elements in behave.
 
 import os.path
 import sys
+from enum import Enum
+
 import six
+
 from behave.capture import Captured
 from behave.textutil import text as _text
-from enum import Enum
+
+if six.PY2:
+    # -- USE: Python3 backport for better unicode compatibility.
+    import traceback2 as traceback
+else:
+    import traceback
 
 
 PLATFORM_WIN = sys.platform.startswith("win")
@@ -281,6 +289,24 @@ class BasicStatement(object):
         self.exc_traceback = None
         self.error_message = None
 
+    def send_status(self):
+        """Emit the volatile attributes of this model in a primitive dict"""
+        ret = {
+            "exception": self.exception,
+            "error_message": self.error_message,
+            "exc_traceback": self.exc_traceback,
+            "captured": self.captured.send_status(),
+        }
+        return ret
+
+    def recv_status(self, value):
+        """Set volatile attributes from a `send_status()` primitive value"""
+        for key in "exception", "error_message", "exc_traceback":
+            if key in value:
+                setattr(self, key, value[key])
+        if "captured" in value:
+            self.captured.recv_status(value["captured"])
+
     @property
     def filename(self):
         # return os.path.abspath(self.location.filename)
@@ -298,9 +324,27 @@ class BasicStatement(object):
         self.exc_traceback = None
         self.error_message = None
 
+    def send_status(self):
+        """Emit the volatile attributes of this model in a primitive dict"""
+        ret = {
+            "exception": self.exception,
+            "error_message": self.error_message,
+            "exc_traceback": self.exc_traceback,
+            "captured": self.captured.send_status(),
+        }
+        return ret
+
+    def recv_status(self, value):
+        """Set volatile attributes from a `send_status()` primitive value"""
+        for key in "exception", "error_message", "exc_traceback":
+            if key in value:
+                setattr(self, key, value[key])
+        if "captured" in value:
+            self.captured.recv_status(value["captured"])
+
     def store_exception_context(self, exception):
         self.exception = exception
-        self.exc_traceback = sys.exc_info()[2]
+        self.exc_traceback = traceback.format_tb(sys.exc_info()[2])
 
     def __hash__(self):
         # -- NEEDED-FOR: PYTHON3
@@ -404,6 +448,10 @@ class TagAndStatusStatement(BasicStatement):
             self._cached_status = self.compute_status()
         return self._cached_status
 
+    @property
+    def is_finished(self):
+        return self._cached_status in self.final_status
+
     def set_status(self, value):
         if isinstance(value, six.string_types):
             value = Status.from_name(value)
@@ -419,6 +467,23 @@ class TagAndStatusStatement(BasicStatement):
 
     def compute_status(self):
         raise NotImplementedError
+
+    def send_status(self):
+        ret = super(TagAndStatusStatement, self).send_status()
+        ret["status"] = self._cached_status
+        ret["should_skip"] = self.should_skip
+        ret["skip_reason"] = self.skip_reason
+        return ret
+
+    def recv_status(self, value):
+        assert self._cached_status in (Status.untested, Status.skipped), self._cached_status
+        super(TagAndStatusStatement, self).recv_status(value)
+        if "should_skip" in value:
+            self.should_skip = value["should_skip"]
+        if "skip_reason" in value:
+            self.skip_reason = value["skip_reason"]
+        if "status" in value:
+            self._cached_status = value["status"]
 
 
 class Replayable(object):

--- a/behave/model_core.py
+++ b/behave/model_core.py
@@ -289,24 +289,6 @@ class BasicStatement(object):
         self.exc_traceback = None
         self.error_message = None
 
-    def send_status(self):
-        """Emit the volatile attributes of this model in a primitive dict"""
-        ret = {
-            "exception": self.exception,
-            "error_message": self.error_message,
-            "exc_traceback": self.exc_traceback,
-            "captured": self.captured.send_status(),
-        }
-        return ret
-
-    def recv_status(self, value):
-        """Set volatile attributes from a `send_status()` primitive value"""
-        for key in "exception", "error_message", "exc_traceback":
-            if key in value:
-                setattr(self, key, value[key])
-        if "captured" in value:
-            self.captured.recv_status(value["captured"])
-
     @property
     def filename(self):
         # return os.path.abspath(self.location.filename)

--- a/behave/reporter/junit.py
+++ b/behave/reporter/junit.py
@@ -70,25 +70,20 @@ Best sources are:
 # pylint: enable=line-too-long
 
 from __future__ import absolute_import
-
-import codecs
 import os.path
+import codecs
 import re
 import sys
-from datetime import datetime
 from xml.etree import ElementTree
-
-import six
-
-from behave.formatter import ansi_escapes
+from datetime import datetime
+from behave.reporter.base import Reporter
 from behave.model import Rule, Scenario, ScenarioOutline, Step
 from behave.model_core import Status
+from behave.formatter import ansi_escapes
 from behave.model_describe import ModelDescriptor
-from behave.reporter.base import Reporter
-from behave.textutil import indent, make_indentation
-from behave.textutil import text as _text
+from behave.textutil import indent, make_indentation, text as _text
 from behave.userdata import UserDataNamespace
-
+import six
 if six.PY2:
     # -- USE: Python3 backport for better unicode compatibility.
     import traceback2 as traceback

--- a/behave/reporter/summary.py
+++ b/behave/reporter/summary.py
@@ -8,10 +8,10 @@ from __future__ import absolute_import, division, print_function
 import sys
 from time import time as time_now
 
-from behave.formatter.base import StreamOpener
 from behave.model import Rule, ScenarioOutline  # MAYBE: Scenario
 from behave.model_core import Status
 from behave.reporter.base import Reporter
+from behave.formatter.base import StreamOpener
 
 try:
     # requires py>=3.3 or 3.5 for all platforms

--- a/behave/reporter/summary.py
+++ b/behave/reporter/summary.py
@@ -148,7 +148,6 @@ class SummaryReporter(Reporter):
         self.step_summary = {Status.undefined.name: 0}
         self.step_summary.update(summary_zero_data)
         self.start = monotonic()
-        self.duration = 0.0
         self.run_starttime = 0
         self.run_endtime = 0
         self.failed_scenarios = []
@@ -199,8 +198,8 @@ class SummaryReporter(Reporter):
 
         # -- DURATION:
         if with_duration:
-            run_duration = monotonic() - self.start
-            timings = (int(run_duration / 60.0), run_duration % 60)
+            duration = monotonic() - self.start
+            timings = (int(duration / 60.0), duration % 60)
             stream.write('Took %dm%02.3fs\n' % timings)
 
     # -- REPORTER-API:
@@ -233,7 +232,6 @@ class SummaryReporter(Reporter):
                 self.process_scenario(run_item)
 
     def process_feature(self, feature):
-        self.duration += feature.duration
         self.feature_summary[feature.status.name] += 1
         self.process_run_items_for(feature)
 

--- a/behave/reporter/summary.py
+++ b/behave/reporter/summary.py
@@ -4,12 +4,20 @@ Provides a summary after each test run.
 """
 
 from __future__ import absolute_import, division, print_function
+
 import sys
 from time import time as time_now
+
+from behave.formatter.base import StreamOpener
 from behave.model import Rule, ScenarioOutline  # MAYBE: Scenario
 from behave.model_core import Status
 from behave.reporter.base import Reporter
-from behave.formatter.base import StreamOpener
+
+try:
+    # requires py>=3.3 or 3.5 for all platforms
+    from time import monotonic
+except ImportError:
+    from time import time as monotonic
 
 
 # ---------------------------------------------------------------------------
@@ -139,6 +147,7 @@ class SummaryReporter(Reporter):
         self.scenario_summary = summary_zero_data.copy()
         self.step_summary = {Status.undefined.name: 0}
         self.step_summary.update(summary_zero_data)
+        self.start = monotonic()
         self.duration = 0.0
         self.run_starttime = 0
         self.run_endtime = 0
@@ -190,7 +199,8 @@ class SummaryReporter(Reporter):
 
         # -- DURATION:
         if with_duration:
-            timings = (int(self.duration / 60.0), self.duration % 60)
+            run_duration = monotonic() - self.start
+            timings = (int(run_duration / 60.0), run_duration % 60)
             stream.write('Took %dm%02.3fs\n' % timings)
 
     # -- REPORTER-API:

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -10,18 +10,19 @@ import os.path
 import sys
 import warnings
 import weakref
-from enum import Enum
 
 import six
 
-from behave._types import ExceptionUtil
 from behave.api.runner import ITestRunner
+from behave._types import ExceptionUtil
 from behave.capture import CaptureController
 from behave.exception import ConfigError
 from behave.formatter._registry import make_formatters
-from behave.runner_util import (PathManager, collect_feature_locations,
-                                exec_file, load_step_modules, parse_features)
+from behave.runner_util import \
+    collect_feature_locations, parse_features, \
+    exec_file, load_step_modules, PathManager
 from behave.step_registry import registry as the_step_registry
+from enum import Enum
 
 if six.PY2:
     # -- USE PYTHON3 BACKPORT: With unicode traceback support.

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -10,19 +10,18 @@ import os.path
 import sys
 import warnings
 import weakref
+from enum import Enum
 
 import six
 
-from behave.api.runner import ITestRunner
 from behave._types import ExceptionUtil
+from behave.api.runner import ITestRunner
 from behave.capture import CaptureController
 from behave.exception import ConfigError
 from behave.formatter._registry import make_formatters
-from behave.runner_util import \
-    collect_feature_locations, parse_features, \
-    exec_file, load_step_modules, PathManager
+from behave.runner_util import (PathManager, collect_feature_locations,
+                                exec_file, load_step_modules, parse_features)
 from behave.step_registry import registry as the_step_registry
-from enum import Enum
 
 if six.PY2:
     # -- USE PYTHON3 BACKPORT: With unicode traceback support.
@@ -418,7 +417,7 @@ class Context(object):
                     if step.error_message:
                         message += "\nSubstep info: %s\n" % step.error_message
                         message += u"Traceback (of failed substep):\n"
-                        message += u"".join(traceback.format_tb(step.exc_traceback))
+                        message += u"".join(step.exc_traceback)
                     # message += u"\nTraceback (of context.execute_steps()):"
                     assert False, message
 

--- a/behave/runner_parallel.py
+++ b/behave/runner_parallel.py
@@ -16,6 +16,7 @@ import multiprocessing
 
 import six
 
+from behave.api.runner import ITestRunner
 from behave.formatter._registry import make_formatters
 from behave.model import Feature, NoMatch, Scenario, ScenarioOutline
 from behave.runner import Context, Runner
@@ -26,6 +27,10 @@ if six.PY2:
     import Queue as queue
 else:
     import queue
+
+
+# set method to "fork" in order to prevent Pool issue on Mac
+multiprocessing.set_start_method('fork')
 
 
 class MasterParallelRunner(Runner):
@@ -389,3 +394,10 @@ class ProcessClientExecutor(Runner):
                   or cleanups_failed)
                   # XXX-MAYBE: or context.failed)
         return failed
+
+
+# -----------------------------------------------------------------------------
+# REGISTER RUNNER-CLASSES:
+# -----------------------------------------------------------------------------
+ITestRunner.register(FeatureParallelRunner)
+ITestRunner.register(ScenarioParallelRunner)

--- a/behave/runner_parallel.py
+++ b/behave/runner_parallel.py
@@ -1,0 +1,391 @@
+# -*- coding: UTF-8 -*-
+"""
+This module provides multiprocessing Runner class for Behave
+
+Core functionality is based on https://github.com/behave/behave/pull/616
+
+Additional improvements: 
+ - before_all() and after_all() hooks are executed once instead of being run in each parallel processes
+ - added handling for max number of processes
+ - fixed FeatureRunner to correctly call super class
+ - fixed Feature/Scenario calculation before kicking off parallel processes
+ - fixed test duration calculation in Summary and Junit
+"""
+
+import multiprocessing
+
+import six
+
+from behave.formatter._registry import make_formatters
+from behave.model import Feature, NoMatch, Scenario, ScenarioOutline
+from behave.runner import Context, Runner
+from behave.runner_util import parse_features
+from behave.step_registry import registry as the_step_registry
+
+if six.PY2:
+    import Queue as queue
+else:
+    import queue
+
+
+class MasterParallelRunner(Runner):
+    """Master parallel runner: scans jobs and distributes to slaves
+        This runner should not do any "processing" tasks, apart from scanning
+        the feature files and their scenarios. It then spawns processing nodes
+        and lets them consume the queue of tasks scheduled.
+    """
+    def __init__(self, config):
+        super(MasterParallelRunner, self).__init__(config)
+        self.jobs_map = {}
+        self.jobsq = multiprocessing.JoinableQueue()
+        self.resultsq = multiprocessing.Queue()
+        self._reported_features = set()
+        self.results_fail = False
+
+    def run_with_paths(self):
+        feature_locations = [
+            filename for filename in self.feature_locations() if not self.config.exclude(filename)
+            ]
+        # hooks themselves not used, but 'environment.py' loaded
+        self.load_hooks()
+        # step definitions are needed here for formatters only
+        self.load_step_definitions()
+
+        # get list of all available features
+        features = parse_features(feature_locations, language=self.config.lang)
+
+        # leave only features/scenarios which should be run
+        [self.features.append(feature) for feature in features if feature.should_run(self.config)]
+
+        # get feature/scenario count for multiprocessing
+        feature_count, scenario_count = self.scan_features()
+        n_jobs = len(self.jobs_map)
+        n_processes = self.config.jobs
+
+        print("\n\nINFO: {0} scenario(s) and {1} feature(s) queued for"
+                " consideration by {2} workers.\n\n"
+               .format(scenario_count, feature_count, n_processes))
+        processes = []
+
+        # -- STEP: Prepare formatters to write messages to the default Stream (Master Process)
+        stream_openers = self.config.outputs
+        self.formatters = make_formatters(self.config, stream_openers)
+
+        # -- STEP: init default context for Master Process to execute before/after_all() hooks
+        self.context = Context(self)
+        self.setup_capture()
+        self.run_hook("before_all", self.context)
+
+        # -- STEP: Run each test as a separate Process
+        for i in range(n_processes):
+            client = ProcessClientExecutor(self, i)
+            p = multiprocessing.Process(
+                target=client.run_executor,
+                args=[self.context]
+                )
+            processes.append(p)
+            p.start()
+            del p
+
+        print("INFO: started {0} workers for {1} jobs.".format(n_processes, n_jobs))
+
+        while (not self.jobsq.empty()):
+            # 1: consume results while tests are running
+            self.consume_results()
+            if not any([p.is_alive() for p in processes]):
+                break
+
+        # wait for all jobs to be processed
+        if any([p.is_alive() for p in processes]):
+            self.jobsq.join()
+            print("INFO: all jobs have been processed")
+
+            while self.consume_results(timeout=0.1):
+                # 2: remaining results
+                pass
+
+            # then, wait for all workers to exit:
+            [p.join() for p in processes]
+        print("INFO: all sub-processes have returned")
+
+        # -- STEP: Run after_all() hook
+        self.run_hook("after_all", self.context)
+
+        while self.consume_results(timeout=0.1):
+            # 3: just in case some arrive late in the pipe
+            pass
+
+        for f in self.features:
+            # make sure all features (including ones that have not returned) are printed
+            self._output_feature(f)
+
+        # notify formatters and reporters that test run has finished
+        for formatter in self.formatters:
+            formatter.close()
+        for reporter in self.config.reporters:
+            reporter.end()
+
+        return self.results_fail
+
+    def scan_features(self):
+        raise NotImplementedError
+
+    def put_item_into_queue(self, item: Scenario | Feature):
+        item_id = id(item)
+        self.jobs_map[item_id] = item
+        self.jobsq.put(item_id)
+
+    def consume_results(self, timeout=1):
+        """Get item result in real-time using multiprocessing pipe. 
+        
+        Required for formatters to work correctly
+        """
+
+        try:
+            job_id, result = self.resultsq.get(timeout=timeout)
+        except queue.Empty:
+            return False
+
+        if job_id is None and result == 'set_fail':
+            self.results_fail = True
+            return True
+
+        item = self.jobs_map.get(job_id)
+        if item is None:
+            print("ERROR: job_id=%x not found in master map" % job_id)
+            return True
+
+        try:
+            item.recv_status(result)
+            if isinstance(item, Feature):
+                self._output_feature(item)
+            elif isinstance(item, Scenario):
+                feature = item.feature
+                print("INFO: scenario finished: %s %s" % (item.name, item.status))
+                if feature.is_finished:
+                    self._output_feature(feature)
+        except Exception as e:
+            print("ERROR: cannot receive status for %r: %s" % (item, e))
+            if self.config.wip and not self.config.quiet:
+                import traceback
+                traceback.print_exc()
+        return True
+
+    def _output_feature(self, feature):
+        if id(feature) in self._reported_features:
+            return
+        self._reported_features.add(id(feature))
+
+        def _out_scenario(scenario, formatter):
+            formatter.scenario(scenario)
+            for step in scenario.steps:
+                formatter.step(step)
+            for step in scenario.steps:
+                match = the_step_registry.find_match(step)
+                if match:
+                    formatter.match(match)
+                else:
+                    formatter.match(NoMatch())
+                formatter.result(step)
+
+        for formatter in self.formatters:
+            formatter.uri(feature.filename)
+            formatter.feature(feature)
+            if feature.background:
+                formatter.background(feature.background)
+            for scenario in feature.scenarios:
+                if isinstance(scenario, ScenarioOutline):
+                    for scen in scenario.scenarios:
+                        _out_scenario(scen, formatter)
+                else:
+                    _out_scenario(scenario, formatter)
+            # notify formatter the end of current test
+            formatter.eof()
+
+        for reporter in self.config.reporters:
+            reporter.feature(feature)
+
+
+class FeatureParallelRunner(MasterParallelRunner):
+    """Adds features to job queue"""
+
+    def scan_features(self):
+        n_features = 0
+
+        for feature in self.features:
+            self.put_item_into_queue(feature)
+            n_features += 1
+
+            # compute background steps for Scenarios and SubScenarios
+            for scenario in feature.scenarios:
+                scenario.background_steps
+                if isinstance(scenario, ScenarioOutline):
+                    for sub_scenario in scenario.scenarios:
+                        sub_scenario.background_steps
+
+        return n_features, 0
+
+
+class ScenarioParallelRunner(MasterParallelRunner):
+    """Adds each scenario/sub-scenario to job queue"""
+
+    def scan_features(self):
+        n_features = n_scenarios = 0
+
+        for feature in self.features:
+            # compute background steps for Scenarios and SubScenarios
+            for scenario in feature.scenarios:
+                scenario.background_steps
+                if scenario.type == 'scenario':
+                    self.put_item_into_queue(scenario)
+                    n_scenarios += 1
+                else:
+                    for sub_scenario in scenario.scenarios:
+                        sub_scenario.background_steps
+                        self.put_item_into_queue(sub_scenario)
+                        n_scenarios += 1
+
+        return n_features, n_scenarios
+
+
+class ProcessClientExecutor(Runner):
+    """Multiprocessing Client Executor: picks "job" from parent queue and runs it
+        Each client is tagged with a `num` to appear in outputs etc.
+    """
+    def __init__(self, parent, num):
+        super(ProcessClientExecutor, self).__init__(parent.config)
+        self.num = num
+        self.jobs_map = parent.jobs_map
+        self.jobsq = parent.jobsq
+        self.resultsq = parent.resultsq
+
+    def iter_queue(self):
+        """Iterator fetching features from the queue
+            Note that this iterator is lazy and multiprocess-affected:
+            it cannot know its set of features in advance, will dynamically
+            yield ones as found in the queue
+        """
+        while True:
+            try:
+                job_id = self.jobsq.get(timeout=1.0)
+            except queue.Empty:
+                break
+
+            job = self.jobs_map.get(job_id, None)
+            if job is None:
+                print("ERROR: missing job id=%s from map" % job_id)
+                self.jobsq.task_done()
+                continue
+
+            if isinstance(job, Feature):
+                yield job
+            elif isinstance(job, Scenario):
+                # construct a dummy feature, having only this scenario
+                kwargs = {}
+                for k in ('filename', 'line', 'keyword', 'name', 'tags',
+                          'description', 'background', 'language'):
+                    kwargs[k] = getattr(job.feature, k)
+                kwargs['scenarios'] = [job]
+                orig_parser = job.feature.parser
+                feature = Feature(**kwargs)
+                feature.parser = orig_parser
+                yield feature
+            else:
+                raise TypeError("Don't know how to process: %s" % type(job))
+
+            try:
+                self.resultsq.put((job_id, job.send_status()))
+            except Exception as e:
+                print("ERROR: Cannot send result for {1}: {0}".format(e, job.name))
+
+            self.jobsq.task_done()
+
+    def update_executors_context(self, master_context: Context):
+        """Loads values from master context into the local context
+        
+        It's needed to have access to context objects, which were initialized in before_all()
+        In this case, each ProcessClientExecutor.context will have a reference to the same object
+        created in Master Process.
+        """
+        for k, v in master_context._root.items():
+            if k not in self.context._root and k not in ["stdout_capture", "stderr_capture"]:
+                try:
+                    setattr(self.context, k, v)
+                    self.context._origin[k] = master_context._origin[k]
+                except BaseException as e:
+                    print(f"ERROR: Failed to updated context with {k} --> {v}: ", e)
+
+    def run_executor(self, master_context: Context):
+        with self.path_manager:
+            self.setup_paths()
+            return self.run_with_paths(master_context)
+
+    def run_with_paths(self, master_context: Context):
+        self.context = Context(self)
+        self.update_executors_context(master_context)
+
+        self.load_hooks()
+        self.load_step_definitions()
+        assert not self.aborted
+
+        failed = self.run_model(features=self.iter_queue())
+        if failed:
+            self.resultsq.put((None, 'set_fail'))
+        self.resultsq.close()
+
+    def run_model(self, features=None):
+        # pylint: disable=too-many-branches
+        if not self.context:
+            self.context = Context(self)
+        if self.step_registry is None:
+            self.step_registry = the_step_registry
+        if features is None:
+            features = self.features
+
+        # -- ENSURE: context.execute_steps() works in weird cases (hooks, ...)
+        self.hook_failures = 0
+        self.setup_capture()
+
+        run_feature = not self.aborted
+        failed_count = 0
+        undefined_steps_initial_size = len(self.undefined_steps)
+        for feature in features:
+            if run_feature:
+                try:
+                    self.feature = feature
+                    for formatter in self.formatters:
+                        formatter.uri(feature.filename)
+
+                    failed = feature.run(self)
+                    if failed:
+                        failed_count += 1
+                        if self.config.stop or self.aborted:
+                            # -- FAIL-EARLY: After first failure.
+                            run_feature = False
+                except KeyboardInterrupt:
+                    self.abort(reason="KeyboardInterrupt")
+                    failed_count += 1
+                    run_feature = False
+
+            # -- ALWAYS: Report run/not-run feature to reporters.
+            # REQUIRED-FOR: Summary to keep track of untested features.
+            for reporter in self.config.reporters:
+                reporter.feature(feature)
+
+        # -- CLEAN-UP:
+        # pylint: disable=protected-access, broad-except
+        cleanups_failed = False
+        try:
+            # Without dropping the last context layer
+            self.context._do_cleanups()
+        except Exception:
+            cleanups_failed = True
+
+        if self.aborted:
+            print("\nABORTED: By user.")
+
+        failed = ((failed_count > 0) or self.aborted or (self.hook_failures > 0)
+                  or (len(self.undefined_steps) > undefined_steps_initial_size)
+                  or cleanups_failed)
+                  # XXX-MAYBE: or context.failed)
+        return failed

--- a/docs/behave.rst
+++ b/docs/behave.rst
@@ -55,10 +55,16 @@ You may see the same information presented below at any time using ``behave
 
     Directory in which to store JUnit reports.
 
-.. option:: -j, --jobs, --parallel
+.. option:: -j, --jobs, --parallel-processes, --workers
 
-    Number of concurrent jobs to use (default: 1). Only supported by test
-    runners that support parallel execution.
+    Number of concurrent jobs to use (default: 1). 
+    Only supported by test runners that support parallel execution.
+
+.. option:: --parallel-element
+
+    If you used the --jobs option, then this will control how the tests get 
+    parallelized: by "scenario" (default) or by "feature".
+    Only supported by test runners that support parallel execution.
 
 .. option:: -f, --format
 
@@ -396,10 +402,19 @@ Configuration Parameters
 .. index::
     single: configuration param; jobs
 
-.. describe:: jobs : positive_number
+.. describe:: jobs : validate_jobs_number
 
-    Number of concurrent jobs to use (default: 1). Only supported by test
-    runners that support parallel execution.
+    Number of concurrent jobs to use (default: 1). Should be a positive number or "auto".
+    If "auto" was provided - will set number of jobs according to number of CPU cores.
+    Only supported by test runners that support parallel execution.
+
+.. index::
+    single: configuration param; parallel_element
+
+.. describe:: parallel_element : text
+
+    Control how the tests get parallelized: by "scenario" (default) or by "feature"
+    Only supported by test runners that support parallel execution.
 
 .. index::
     single: configuration param; default_format


### PR DESCRIPTION
This PR adds two new Behave Runners which support parallel execution: `ScenarioParallelRunner` and `FeatureParallelRunner`.

CLI args for parallel execution:
- `-j`, `--jobs`, `--workers` (int or "auto") - set number of parallel processes. If "auto" was provided - set number to match number of CPU cores on your computer. (same as pytest-xdist)
- `--parallel_element` ("scenario", "feature") - divide tests by feature or by scenario. Default: scenario.

**Usage:**
`behave test/features -j auto`
`behave test/features -j 2 --parallel-element=feature`
`behave test/features -j 2 --runner=parallel_feature`
`behave test/features -j 20 --runner=parallel_scenario`

Print help to list available runners:
`behave --runner=help`

```
AVAILABLE RUNNERS:
  default            = behave.runner:Runner
  parallel_feature   = behave.runner_parallel:FeatureParallelRunner
  parallel_scenario  = behave.runner_parallel:ScenarioParallelRunner
```